### PR TITLE
Get version in README updated.

### DIFF
--- a/kmd/linux/verus-cli/README.txt
+++ b/kmd/linux/verus-cli/README.txt
@@ -1,4 +1,4 @@
-VerusCoin Command Line Tools v0.3.3-beta
+VerusCoin Command Line Tools v0.3.4
 Contents:
 komodod - VerusCoin's enhanced Komodo daemon
 komodo-cli - VerusCoin's Komodo command line utility

--- a/kmd/mac/verus-cli/README.txt
+++ b/kmd/mac/verus-cli/README.txt
@@ -1,4 +1,4 @@
-VerusCoin Command Line Tools v0.3.3-beta
+VerusCoin Command Line Tools v0.3.4
 Contents:
 Brewfile - configuration for brew that specifies verus-cli requirements. Used via a "brew Brewfile" command. 
 komodod - VerusCoin's enhanced Komodo daemon.

--- a/kmd/windows/verus-cli/README.txt
+++ b/kmd/windows/verus-cli/README.txt
@@ -1,4 +1,4 @@
-VerusCoin Command Line Tools v0.3.3-beta
+VerusCoin Command Line Tools v0.3.4
 Contents:
 komodod.exe - VerusCoin's enhanced Komodo daemon
 komodo-cli.exe - iVerusCoin's Komodo command line utility


### PR DESCRIPTION
Get version updated to 0.3.4, no beta, in the verus-cli README.txt files for all three flavors.