### PR TITLE
Fix progress estimate by fixing checkpoint data

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -264,15 +264,17 @@ void *chainparams_commandline(void *ptr)
         checkpointData = //(Checkpoints::CCheckpointData)
             {
                 boost::assign::map_list_of
-                (0, mainParams.consensus.hashGenesisBlock),
-                //(2500, uint256S("0x0e6a3d5a46eba97c4e7618d66a39f115729e1176433c98481124c2bf733aa54e"))
-                //(15000, uint256S("0x00f0bd236790e903321a2d22f85bd6bf8a505f6ef4eddb20458a65d37e14d142")),
-                //(100000, uint256S("0x0f02eb1f3a4b89df9909fec81a4bd7d023e32e24e1f5262d9fc2cc36a715be6f")),
-                (int64_t)1481120910,     // * UNIX timestamp of last checkpoint block
-                (int64_t)110415,         // * total number of transactions between genesis and last checkpoint
-                                //   (the tx=... number in the SetBestChain debug.log lines)
+                (0, mainParams.consensus.hashGenesisBlock)
+                (10000, uint256S("0xac2cd7d37177140ea4991cf630c0b9c7f94d707b84fb0351bf3a44856d2ae5dc"))
+                (20000, uint256S("0xb0e8cb9f77aaa7ff5bd90d6c08d06f4c4bf03e00c2b8a35a042e760845590c8a"))
+                (30000, uint256S("0xf2112ca577338ad7104bf905fa6a63d36b17a86f914c97b73cd31d43fcd7557c"))
+                (40000, uint256S("0x00000000008f83378dab727864b763ce91a4ea5f75d55939c0c1390cfb8c38f1"))
+                (49170, uint256S("0x2add646c0089871ec2379f02f7cd60b3af6efd9c152a6f16fc10925458c270cc")),
+                (int64_t)1529910234,    // * UNIX timestamp of last checkpoint block
+                (int64_t)63661,         // * total number of transactions between genesis and last checkpoint
+                                        //   (the tx=... number in the SetBestChain debug.log lines)
                 (double)2777            // * estimated number of transactions per day after checkpoint
-                                //   total number of tx / (checkpoint block height / (24 * 24))
+                                        //   total number of tx / (checkpoint block height / (24 * 24))
             };
 
     }


### PR DESCRIPTION
The number of transactions since the last checkpoint block was set to
over 100K, but there were no checkpoint blocks other than genesis,
and the timestamp of last checkpoint block was incorrect as well. These
led to the progress indicator always being very close to zero.

This adds checkpoint blocks rougly every 10K blocks and corrects the
other metadata.

Here is an example of correct progress indicators in debug.log:
```
2018-06-25 07:18:46 UpdateTip: new best=000000000003668ccadd1d535efa2ee133291fb0f9a207467a2c5921ebee64df  height=49180  log2_work=54.642163  tx=113160  date=2018-06-25 07:16:45 progress=0.999938  cache=0.0MiB(1tx)
2018-06-25 07:18:34 LoadBlockIndexDB: hashBestChain=00000000000d7561bb5f6318eab2559347b778eaa12db97ed84ec3239bf907c8 height=49179 date=2018-06-25 07:15:50 progress=0.999915
2018-06-25 07:19:52 UpdateTip: new best=b7420f5c8e1fa1b8b8915060515075c5ccbc69b1b53cf840e982bde0ec756422  height=49182  log2_work=54.642226  tx=113163  date=2018-06-25 07:18:30 progress=0.999958  cache=0.0MiB(5tx)
```

This was tested on OS X.
