### PR TITLE
Use the 64 bit reverser, the only one provided.

### DIFF
--- a/src/snark/libsnark/common/utils.hpp
+++ b/src/snark/libsnark/common/utils.hpp
@@ -25,7 +25,7 @@ size_t log2(size_t n);
 
 inline size_t exp2(size_t k) { return UINT64_C(1) << k; }
 
-size_t bitreverse(size_t n, const size_t l);
+uint64_t bitreverse(uint64_t n, const uint64_t l);
 bit_vector int_list_to_bits(const std::initializer_list<uint64_t> &l, const size_t wordsize);
 int64_t div_ceil(int64_t x, int64_t y);
 


### PR DESCRIPTION
Without this it uses a 32 bit size_t which the library does not provide, so the mangling has an mm vs. yy mismatch at the end (in Mac terms, it's calling with 32 bit unsigned longs but libsnark provides a 64 bit unsigned long long implementation)
Safe to use uint64_t across Mac, Linux and Windows.