### PR TITLE
fix segfaults after build with gcc-8

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -387,7 +387,7 @@ public:
         nSolution      = block.nSolution;
     }
 
-    int32_t SetHeight(int32_t height)
+    void SetHeight(int32_t height)
     {
         this->chainPower.nHeight = height;
     }

--- a/src/cheatcatcher.h
+++ b/src/cheatcatcher.h
@@ -41,6 +41,7 @@ class CTxHolder
             utxo = txh.utxo;
             height = txh.height;
             tx = txh.tx;
+	    return *this;
         }
 };
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -142,8 +142,8 @@ struct Params {
     int64_t AveragingWindowTimespan() const { return nPowAveragingWindow * nPowTargetSpacing; }
     int64_t MinActualTimespan() const { return (AveragingWindowTimespan() * (100 - nPowMaxAdjustUp  )) / 100; }
     int64_t MaxActualTimespan() const { return (AveragingWindowTimespan() * (100 + nPowMaxAdjustDown)) / 100; }
-    int32_t SetSaplingHeight(int32_t height) { vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = height; }
-    int32_t SetOverwinterHeight(int32_t height) { vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = height; }
+    void SetSaplingHeight(int32_t height) { vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = height; }
+    void SetOverwinterHeight(int32_t height) { vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = height; }
     unsigned int EquihashN() const { return nEquihashN; }
     unsigned int EquihashK() const { return nEquihashK; }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -302,7 +302,7 @@ public:
         }
     }
 
-    bool SetVersionByHeight(uint32_t height)
+    void SetVersionByHeight(uint32_t height)
     {
         CVerusSolutionVector vsv = CVerusSolutionVector(nSolution);
         if (vsv.SetVersionByHeight(height) && vsv.Version() > 0)

--- a/src/primitives/solutiondata.h
+++ b/src/primitives/solutiondata.h
@@ -266,7 +266,7 @@ class CConstVerusSolutionVector
             return SetVersion(vch, activationHeight.ActiveVersion(height));
         }
 
-        static bool SetDescriptor(std::vector<unsigned char> &vch, CPBaaSSolutionDescriptor d)
+        static void SetDescriptor(std::vector<unsigned char> &vch, CPBaaSSolutionDescriptor d)
         {
             d.SetVectorBase(vch);
         }
@@ -384,7 +384,7 @@ class CVerusSolutionVector
 
         bool SetVersion(uint32_t v)
         {
-            solutionTools.SetVersion(vch, v);
+            return solutionTools.SetVersion(vch, v);
         }
 
         bool SetVersionByHeight(uint32_t height)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -28,10 +28,12 @@ public:
 UniValue RPCCallRoot(const string& strMethod, const UniValue& params, int timeout)
 {
     assert(false);
+    return NullUniValue;
 }
 
-bool SetThisChain(UniValue &chainDefinition)
-{}
+bool SetThisChain(UniValue &chainDefinition) {
+    return true; // (?) pbaas/pbaas.h
+}
 
 int32_t uni_get_int(UniValue uv, int32_t def)
 {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -220,8 +220,10 @@ public:
             if (pk.IsFullyValid())
             {
                 signatures[pk.GetID()] = oneSig;
+		return true;
             }
         }
+	return false;
     }
 
     UniValue ToUniValue() const

--- a/src/script/script_ext.cpp
+++ b/src/script/script_ext.cpp
@@ -70,6 +70,7 @@ const CScriptExt &CScriptExt::AddCheckLockTimeVerify(int64_t unlocktime) const
         *((CScript *)this) << OP_DROP;
         return *this;
     }
+    return *this;
 }
 
 // combined CLTV script and P2PKH


### PR DESCRIPTION
fix segfaults of ./verusd and ./verus with gcc-8 build.
build with fix tested on Debian 10 and Ubuntu 19 which
have gcc-8 by default.