### PR TITLE
update bootstrap URL

### DIFF
--- a/vcutil/fetch-bootstrap.bat
+++ b/vcutil/fetch-bootstrap.bat
@@ -7,7 +7,7 @@ IF %ERRORLEVEL%==0 EXIT 1
 TITLE %PROCESS_NAME%
 
 SETLOCAL EnableDelayedExpansion
-SET BOOTSTRAP_URL=https://bootstrap.veruscoin.io
+SET BOOTSTRAP_URL=https://bootstrap.verus.io
 SET TAR_FOUND=0
 FOR %%x in (tar.exe) DO IF NOT [%%~$PATH:x]==[] SET TAR_FOUND=1
 IF %TAR_FOUND% EQU 1 (

--- a/vcutil/fetch-bootstrap.sh
+++ b/vcutil/fetch-bootstrap.sh
@@ -25,7 +25,7 @@ function set_data_dir() {
   fi
 }
 
-BOOTSTRAP_URL="https://bootstrap.veruscoin.io"
+BOOTSTRAP_URL="https://bootstrap.verus.io"
 BOOTSTRAP_ARCHIVE="VRSC-bootstrap.tar.gz"
 BOOTSTRAP_ARCHIVE_SIG="$BOOTSTRAP_ARCHIVE.verusid"
 SHA256CMD="$(command -v sha256sum || echo shasum)"


### PR DESCRIPTION
Updating the url from the deprecated 'bootstrap.veruscoin.i' to the current 'bootstrap.verus.io' in the fetch-bootstrap scripts.