### PR TITLE
Fix `FALLBACK_DOWNLOAD_PATH` feature and add cleanup commands

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -142,6 +142,12 @@ $(host_prefix)/share/config.site: check-packages
 
 check-packages: check-sources
 
+clean-all: clean
+	@rm -rf $(SOURCES_PATH) x86_64* i686* mips* arm* aarch64*
+
+clean:
+	@rm -rf $(WORK_PATH) $(BASE_CACHE) $(BUILD)
+
 install: check-packages $(host_prefix)/share/config.site
 
 

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -19,15 +19,19 @@ define int_get_all_dependencies
 $(sort $(foreach dep,$(2),$(2) $(call int_get_all_dependencies,$(1),$($(dep)_dependencies))))
 endef
 
-define fetch_file
-(test -f $$($(1)_source_dir)/$(4) || \
-  ( mkdir -p $$($(1)_download_dir) && echo Fetching $(1)... && \
-  ( $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(PRIORITY_DOWNLOAD_PATH)/$(4)" || \
-    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" ) && \
+define fetch_file_inner
+    ( mkdir -p $$($(1)_download_dir) && echo Fetching $(3) from $(2) && \
+    $(build_DOWNLOAD) "$$($(1)_download_dir)/$(4).temp" "$(2)/$(3)" && \
     echo "$(5)  $$($(1)_download_dir)/$(4).temp" > $$($(1)_download_dir)/.$(4).hash && \
     $(build_SHA256SUM) -c $$($(1)_download_dir)/.$(4).hash && \
     mv $$($(1)_download_dir)/$(4).temp $$($(1)_source_dir)/$(4) && \
-    rm -rf $$($(1)_download_dir) ))
+    rm -rf $$($(1)_download_dir) )
+endef
+
+define fetch_file
+    ( test -f $$($(1)_source_dir)/$(4) || \
+    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
 endef
 
 define generate_crate_checksum


### PR DESCRIPTION
- Address issue flagged by output.
- Add 'clean' command to streamline the build process.