### PR TITLE
Fix help text for 'z_getencryptionaddress'

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -870,7 +870,7 @@ UniValue z_getencryptionaddress(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1 || !params[0].isObject())
         throw runtime_error(
-            "z_generateencryptionkey '{(\"address\":\"zaddress present in wallet\" | \"seed\":\"wallet seed for address\", \"hdindex\":n - address to derive from seed | \"rootkey\":\"extended private key\"),\n"
+            "z_getencryptionaddress '{(\"address\":\"zaddress present in wallet\" | \"seed\":\"wallet seed for address\", \"hdindex\":n - address to derive from seed | \"rootkey\":\"extended private key\"),\n"
             "                          \"fromid\":\"id@ or i-address\",\n"
             "                          \"toid\":\"id@ or i-address\",\n"
             "                          \"returnsecret\": true | false}'\n"
@@ -893,13 +893,13 @@ UniValue z_getencryptionaddress(const UniValue& params, bool fHelp)
             "}\n"
             "\nExamples:\n"
             "\nExample1 description\n"
-            + HelpExampleCli("z_generateencryptionkey", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
+            + HelpExampleCli("z_getencryptionaddress", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
             "\nExample2 description\n"
-            + HelpExampleCli("z_generateencryptionkey", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
+            + HelpExampleCli("z_getencryptionaddress", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
             "\nExample3 description\n"
-            + HelpExampleCli("z_generateencryptionkey", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
+            + HelpExampleCli("z_getencryptionaddress", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}") +
             "\nExample4 description\n"
-            + HelpExampleRpc("z_generateencryptionkey", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}")
+            + HelpExampleRpc("z_getencryptionaddress", "'{\"address\":\"localzaddress\",\"fromid\":\"bob@\",\"toid\":\"alice@\"}")
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
- Currently this RPC is not documented in help text
- Help text incorrectly shows a 'z_generateencryptionkey', which does not actually exist

**Steps to reproduce:**

1. `./src/verus help` shows:

```z_generateencryptionkey '{("address":"zaddress present in wallet" | "seed":"wallet seed for address", "hdindex":n - address to derive from seed | "rootkey":"extended private key"),
```

2. But, calling `./src/verus help z_generateencryptionkey` yields:

```
help: unknown command: z_generateencryptionkey
```

3. Further, `./src/verus help z_getencryptionaddress` output is also incorrect:

```./src/verus help z_getencryptionaddress
z_generateencryptionkey '{("address":"zaddress present in wallet" | "seed":"wallet seed for address", "hdindex":n - address to derive from seed | "rootkey":"extended private key"),
                          "fromid":"id@ or i-address",
                          "toid":"id@ or i-address",
                          "returnsecret": true | false}'

Returns z-address, viewing key, and optionally an extended secret key.

Arguments:
   "address"          (string, optional) z-address that is present in this wallet
   "seed"             (string, optional) raw wallet seed
   "hdindex"          (number, optional) address to derive from seed (default=0)
   "rootkey"          (string, optional) extended private key
   "fromid"           (string, optional) a key to be used between the fromid and the toid
   "toid"             (string, optional) a key to be used between the fromid and the toid
   "encryptionindex"  (number, optional) can be used as an index to derive the final encryption HD address from the derived seed (default=0)
   "returnsecret"     (bool, optional) if true, returns extended private key - defaults to false


Result:
{
  "extendedviewingkey" : "evk",            (string) "sapling" extended viewing key
  "address" : "encryptionaddress",         (string) The encryption address derived
  "extendedspendingkey" : "encryptionaddress", (string) Spending key for the address, if requested
}

Examples:

Example1 description
> verus z_generateencryptionkey '{"address":"localzaddress","fromid":"bob@","toid":"alice@"}

Example2 description
> verus z_generateencryptionkey '{"address":"localzaddress","fromid":"bob@","toid":"alice@"}

Example3 description
> verus z_generateencryptionkey '{"address":"localzaddress","fromid":"bob@","toid":"alice@"}

Example4 description
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "z_generateencryptionkey", "params": ['{"address":"localzaddress","fromid":"bob@","toid":"alice@"}] }' -H 'content-type: text/plain;' http://127.0.0.1:27486/
```