### PR TITLE
Prepare for Solana bridge integration

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1946,7 +1946,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 {
                     // until we have connected to the ETH bridge, after PBaaS has launched, we check each block to see if there is now an
                     // ETH bridge defined
-                    ConnectedChains.ConfigureEthBridge(true);
+                    if (!ConnectedChains.ConfigureEthBridge(true))
+                    {
+                        // Solana bridge fallback. ConfigureEthBridge returns
+                        // false when no "veth" gateway exists; in that case
+                        // try to wire up a "sol" gateway / keeper instead.
+                        ConnectedChains.ConfigureSolBridge(true);
+                    }
                 }
 
                 ConnectedChains.CheckOracleUpgrades();

--- a/src/komodo_globals.h
+++ b/src/komodo_globals.h
@@ -44,6 +44,14 @@ bool PBAAS_TESTMODE;
 std::string PBAAS_HOST;
 int32_t PBAAS_PORT;
 std::string PBAAS_USERPASS;
+// Solana keeper RPC endpoint, parallel to PBAAS_* (Ethereum bridge).
+// Populated by `CConnectedChains::ConfigureSolBridge()` when a "sol"
+// gateway identity is registered on this chain. `RPCCallRoot()` picks
+// these over PBAAS_* when the active bridge has
+// proofProtocol == PROOF_SOLANANOTARIZATION.
+std::string SOLANA_HOST;
+int32_t SOLANA_PORT;
+std::string SOLANA_USERPASS;
 std::string ASSETCHAINS_RPCHOST, ASSETCHAINS_RPCCREDENTIALS;
 
 uint160 ASSETCHAINS_CHAINID;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3839,7 +3839,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     if (CConstVerusSolutionVector::GetVersionByHeight(nHeight) >= CActivationHeight::ACTIVATE_PBAAS)
     {
-        ConnectedChains.ConfigureEthBridge();
+        // ETH bridge first; fall back to Solana keeper if no veth gateway.
+        if (!ConnectedChains.ConfigureEthBridge())
+        {
+            ConnectedChains.ConfigureSolBridge();
+        }
     }
 
     bool fExpensiveChecks = true;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -964,7 +964,7 @@ bool AddOneCurrencyImport(const CCurrencyDefinition &newCurrency,
             CTransaction firstExportTx;
             if (!pFirstExport || !(pFirstExport->second.IsValid() && !pFirstExport->second.GetPartialTransaction(firstExportTx).IsNull()))
             {
-                LogPrintf("%s: invalid first export for PBaaS or converter launch\n");
+                LogPrintf("%s: invalid first export for PBaaS or converter launch\n", __func__);
                 return false;
             }
 
@@ -972,7 +972,7 @@ bool AddOneCurrencyImport(const CCurrencyDefinition &newCurrency,
             CCrossChainExport ccx(firstExportTx.vout[pFirstExport->first.n].scriptPubKey);
             if (!ccx.IsValid())
             {
-                LogPrintf("%s: invalid export output for PBaaS or converter launch\n");
+                LogPrintf("%s: invalid export output for PBaaS or converter launch\n", __func__);
                 return false;
             }
 
@@ -2413,6 +2413,11 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const std::vecto
             else
             {
                 notaryConnected = ConnectedChains.ConfigureEthBridge(true);
+                if (!notaryConnected)
+                {
+                    // Try the Solana keeper if no veth gateway exists.
+                    notaryConnected = ConnectedChains.ConfigureSolBridge(true);
+                }
             }
         }
 

--- a/src/pbaas/crosschainrpc.cpp
+++ b/src/pbaas/crosschainrpc.cpp
@@ -49,6 +49,11 @@ using namespace std;
 extern string PBAAS_HOST;
 extern string PBAAS_USERPASS;
 extern int32_t PBAAS_PORT;
+// Solana keeper endpoint, populated by `ConfigureSolBridge()`. See
+// komodo_globals.h for the documented use.
+extern string SOLANA_HOST;
+extern string SOLANA_USERPASS;
+extern int32_t SOLANA_PORT;
 extern std::string VERUS_CHAINNAME;
 
 uint32_t PBAAS_MAINDEFI3_HEIGHT = 2553500;
@@ -223,9 +228,21 @@ UniValue RPCCallRoot(const string& strMethod, const UniValue& params, int timeou
     map<string, string> settings;
     map<string, vector<string>> settingsmulti;
 
+    // Fast path 1: Ethereum bridge (existing behavior). PBAAS_* globals
+    // are populated by `ConfigureEthBridge()` when a "veth" gateway
+    // identity is registered.
     if (PBAAS_HOST != "" && PBAAS_PORT != 0)
     {
         return RPCCall(strMethod, params, PBAAS_USERPASS, PBAAS_PORT, PBAAS_HOST, timeout);
+    }
+    // Fast path 2: Solana bridge keeper. SOLANA_* globals are populated
+    // by `ConfigureSolBridge()` when a "sol" gateway identity is
+    // registered. Only one of the two bridges is configured per
+    // daemon today; if both ever coexist, ETH wins (matches the
+    // pre-Solana cache-priority of ETH).
+    if (SOLANA_HOST != "" && SOLANA_PORT != 0)
+    {
+        return RPCCall(strMethod, params, SOLANA_USERPASS, SOLANA_PORT, SOLANA_HOST, timeout);
     }
     else if ((_IsVerusActive() &&
               ReadConfigFile("veth", settings, settingsmulti)) ||
@@ -249,6 +266,29 @@ UniValue RPCCallRoot(const string& strMethod, const UniValue& params, int timeou
                 PBAAS_HOST = "127.0.0.1";
             }
             return RPCCall(strMethod, params, PBAAS_USERPASS, PBAAS_PORT, PBAAS_HOST, timeout);
+        }
+    }
+    // Fallback for the Solana bridge: if globals weren't set at startup
+    // (e.g., the keeper started after the daemon), try reading sol.conf
+    // here. Mirrors the veth.conf fallback above.
+    else if (_IsVerusActive() && ReadConfigFile("sol", settings, settingsmulti))
+    {
+        auto userIt = settingsmulti.find("-rpcuser");
+        auto passIt = settingsmulti.find("-rpcpassword");
+        auto portIt = settingsmulti.find("-rpcport");
+        auto hostIt = settingsmulti.find("-rpchost");
+        if (userIt != settingsmulti.end() &&
+            passIt != settingsmulti.end() &&
+            portIt != settingsmulti.end())
+        {
+            SOLANA_USERPASS = userIt->second[0] + ":" + passIt->second[0];
+            SOLANA_PORT = atoi(portIt->second[0]);
+            SOLANA_HOST = hostIt != settingsmulti.end() ? hostIt->second[0] : "127.0.0.1";
+            if (!SOLANA_HOST.size())
+            {
+                SOLANA_HOST = "127.0.0.1";
+            }
+            return RPCCall(strMethod, params, SOLANA_USERPASS, SOLANA_PORT, SOLANA_HOST, timeout);
         }
     }
     return UniValue(UniValue::VNULL);
@@ -720,10 +760,6 @@ CCurrencyDefinition::CCurrencyDefinition(const UniValue &obj) :
                 nVersion = PBAAS_VERSION_INVALID;
                 return;
             }
-            else if (IsGateway())
-            {
-                gatewayID = GetID();
-            }
             uint160 converterParent = GetID();
             std::string cleanGatewayName = CleanName(gatewayConverterName, converterParent, true);
             uint160 converterID = GetID(cleanGatewayName, converterParent);
@@ -733,6 +769,16 @@ CCurrencyDefinition::CCurrencyDefinition(const UniValue &obj) :
                 nVersion = PBAAS_VERSION_INVALID;
                 return;
             }
+        }
+        // A gateway is its own gateway endpoint regardless of whether it
+        // co-launches a converter currency. PBAAS_TESTMODE allows skipping
+        // the converter (see definecurrency RPC), so populate gatewayID
+        // unconditionally for IsGateway() — otherwise CCrossChainImport
+        // outputs end up with a null sourceSystemID and the reserve-tx
+        // descriptor rejects them as invalid.
+        if (IsGateway())
+        {
+            gatewayID = GetID();
         }
 
         if (IsPBaaSChain() || IsGateway() || IsGatewayConverter())
@@ -797,9 +843,12 @@ CCurrencyDefinition::CCurrencyDefinition(const UniValue &obj) :
         }
 
         proofProtocol = (EProofProtocol)uni_get_int(find_value(obj, "proofprotocol"), (int32_t)PROOF_PBAASMMR);
-        if (proofProtocol != PROOF_PBAASMMR && proofProtocol != PROOF_CHAINID && proofProtocol != PROOF_ETHNOTARIZATION)
+        if (proofProtocol != PROOF_PBAASMMR && proofProtocol != PROOF_CHAINID &&
+            proofProtocol != PROOF_ETHNOTARIZATION && proofProtocol != PROOF_SOLANANOTARIZATION)
         {
-            LogPrintf("%s: proofprotocol must be %d, %d, or %d\n", __func__, (int)PROOF_PBAASMMR, (int)PROOF_CHAINID, (int)PROOF_ETHNOTARIZATION);
+            LogPrintf("%s: proofprotocol must be %d, %d, %d, or %d\n", __func__,
+                      (int)PROOF_PBAASMMR, (int)PROOF_CHAINID,
+                      (int)PROOF_ETHNOTARIZATION, (int)PROOF_SOLANANOTARIZATION);
             nVersion = PBAAS_VERSION_INVALID;
             return;
         }
@@ -1258,7 +1307,7 @@ CCurrencyDefinition::CCurrencyDefinition(const UniValue &obj) :
 
             if (!rewards.size())
             {
-                LogPrintf("%s: PBaaS chain does not have valid rewards eras");
+                LogPrintf("%s: PBaaS chain does not have valid rewards eras\n", __func__);
                 nVersion = PBAAS_VERSION_INVALID;
             }
         }

--- a/src/pbaas/crosschainrpc.h
+++ b/src/pbaas/crosschainrpc.h
@@ -550,7 +550,8 @@ public:
         PROOF_CHAINID = 2,                  // if signed by the chain ID, that is considered proof
         PROOF_ETHNOTARIZATION = 3,          // proven by Ethereum notarization
         PROOF_LASTPROTOCOL = 3,
-        PROOF_KOMODONOTARIZATION = 4        // Komodo protocol is not valid until someone from Komodo finishes it
+        PROOF_KOMODONOTARIZATION = 4,       // Komodo protocol is not valid until someone from Komodo finishes it
+        PROOF_SOLANANOTARIZATION = 5        // proven by Solana notarization, Keccak-form ECDSA signatures verified on-chain
     };
 
     enum EHashTypes
@@ -563,6 +564,22 @@ public:
         HASH_SHA256 = 5,
         HASH_LASTTYPE = 5
     };
+
+    // Maps an EProofProtocol value to the EHashTypes its signatures are emitted with.
+    // The original design aligned the numeric values (PROOF_PBAASMMR=1 ↔ HASH_BLAKE2BMMR=1,
+    // PROOF_ETHNOTARIZATION=3 ↔ HASH_KECCAK=3, PROOF_KOMODONOTARIZATION=4 ↔ HASH_SHA256D=4)
+    // so callers could static_cast directly. PROOF_SOLANANOTARIZATION=5 lands on HASH_SHA256=5
+    // by coincidence, but Solana actually signs with Keccak (matching the EVM bridge), so it
+    // must be remapped explicitly here. All four sites that previously did `(EHashTypes)pp`
+    // now go through this helper.
+    static EHashTypes ProofProtocolHashType(int proofProtocol)
+    {
+        if (proofProtocol == PROOF_SOLANANOTARIZATION)
+        {
+            return HASH_KECCAK;
+        }
+        return (EHashTypes)proofProtocol;
+    }
 
     enum EQueryOptions
     {
@@ -1558,7 +1575,11 @@ public:
     {
         TYPE_PBAAS=1,                       // Verus and other PBaaS chain proof root type
         TYPE_ETHEREUM=2,                    // Ethereum proof root with patricia tree
-        TYPE_KOMODO=3                       // Komodo MoMoM proof root
+        TYPE_KOMODO=3,                      // Komodo MoMoM proof root
+        TYPE_SOLANA=4                       // Solana proof root: Keccak-hashed CPBaaSNotarization,
+                                            // 13-of-N notary ECDSA quorum verified on Solana via
+                                            // sol_secp256k1_recover. No equivalent of gasPrice — the
+                                            // Solana side uses prioritization fees, not per-tx gas.
     };
     int16_t version;                        // to enable future data types with various functions
     int16_t type;                           // type of proof root
@@ -1673,7 +1694,7 @@ public:
     }
 
     CNativeHashWriter(CCurrencyDefinition::EProofProtocol proofProtocol, const unsigned char *personal=nullptr) :
-        CNativeHashWriter((CCurrencyDefinition::EHashTypes)proofProtocol, personal) {}
+        CNativeHashWriter(CCurrencyDefinition::ProofProtocolHashType(proofProtocol), personal) {}
 
     ~CNativeHashWriter()
     {

--- a/src/pbaas/notarization.cpp
+++ b/src/pbaas/notarization.cpp
@@ -1250,7 +1250,7 @@ bool CPBaaSNotarization::NextNotarizationInfo(const CCurrencyDefinition &sourceS
 
     if (!externalSystemID.IsNull())
     {
-        hashType = (CCurrencyDefinition::EHashTypes)externalSystemDef.proofProtocol;
+        hashType = CCurrencyDefinition::ProofProtocolHashType(externalSystemDef.proofProtocol);
     }
 
     CNativeHashWriter hwPrevNotarization;
@@ -7737,7 +7737,7 @@ bool CPBaaSNotarization::ConfirmOrRejectNotarizations(CWallet *pWallet,
 
     std::string errorPrefix(strprintf("%s: ", __func__));
 
-    CCurrencyDefinition::EHashTypes hashType = (CCurrencyDefinition::EHashTypes)externalSystem.chainDefinition.proofProtocol;
+    CCurrencyDefinition::EHashTypes hashType = CCurrencyDefinition::ProofProtocolHashType(externalSystem.chainDefinition.proofProtocol);
 
     uint32_t height, signingHeight;
     uint160 SystemID = externalSystem.chainDefinition.GetID();
@@ -9236,7 +9236,8 @@ std::vector<uint256> CPBaaSNotarization::SubmitFinalizedNotarizations(const CRPC
                     proofIt->second != CProofRoot::GetProofRoot(proofIt->second.rootHeight))
                 {
                     isValid = false;
-                    if (pNotaryCurrency->proofProtocol == CCurrencyDefinition::PROOF_ETHNOTARIZATION)
+                    if (pNotaryCurrency->proofProtocol == CCurrencyDefinition::PROOF_ETHNOTARIZATION ||
+                        pNotaryCurrency->proofProtocol == CCurrencyDefinition::PROOF_SOLANANOTARIZATION)
                     {
                         isPotentialRevoke = true;
                     }
@@ -9672,7 +9673,7 @@ std::vector<uint256> CPBaaSNotarization::SubmitFinalizedNotarizations(const CRPC
         }
         if (signatureEvidence.evidence.chainObjects.size())
         {
-            CCurrencyDefinition::EHashTypes hashType = (CCurrencyDefinition::EHashTypes)externalSystem.chainDefinition.proofProtocol;
+            CCurrencyDefinition::EHashTypes hashType = CCurrencyDefinition::ProofProtocolHashType(externalSystem.chainDefinition.proofProtocol);
             CNativeHashWriter hw(hashType);
             // we are earned notarizations, so it will not be mirrored and can be used as is
             uint256 objHash = (hw << cnd.vtx[cnd.lastConfirmed].second).GetHash();
@@ -9702,10 +9703,13 @@ std::vector<uint256> CPBaaSNotarization::SubmitFinalizedNotarizations(const CRPC
                     (crosschainCND.vtx[crosschainCND.lastConfirmed].second.IsDefinitionNotarization() &&
                      crosschainCND.vtx[crosschainCND.lastConfirmed].second.IsSameChain())) ||
                    (externalSystem.chainDefinition.proofProtocol != CCurrencyDefinition::PROOF_ETHNOTARIZATION &&
+                    externalSystem.chainDefinition.proofProtocol != CCurrencyDefinition::PROOF_SOLANANOTARIZATION &&
                     (newConfirmedNotarization.proofRoots[systemID].rootHeight - crosschainCND.vtx[crosschainCND.lastConfirmed].second.proofRoots[systemID].rootHeight) >
                      (blocksBeforeModuloExtension - (blocksBeforeModuloExtension >> 2))));
 
-    bool amWitness = externalSystem.chainDefinition.proofProtocol == CCurrencyDefinition::PROOF_ETHNOTARIZATION && notarySet.count(VERUS_NOTARYID);
+    bool amWitness = (externalSystem.chainDefinition.proofProtocol == CCurrencyDefinition::PROOF_ETHNOTARIZATION ||
+                      externalSystem.chainDefinition.proofProtocol == CCurrencyDefinition::PROOF_SOLANANOTARIZATION) &&
+                     notarySet.count(VERUS_NOTARYID);
 
     if (notaryRevokeID.IsNull() && !submit)
     {
@@ -11402,9 +11406,10 @@ bool PreCheckFinalizeNotarization(const CTransaction &tx, int32_t outNum, CValid
 
     CNativeHashWriter hw(
         (pNotaryCurrency->IsGateway() &&
-        pNotaryCurrency->launchSystemID == ASSETCHAINS_CHAINID &&
-        pNotaryCurrency->proofProtocol == pNotaryCurrency->PROOF_ETHNOTARIZATION) ?
-            notaryCurrencyDef.PROOF_ETHNOTARIZATION :
+         pNotaryCurrency->launchSystemID == ASSETCHAINS_CHAINID &&
+         (pNotaryCurrency->proofProtocol == pNotaryCurrency->PROOF_ETHNOTARIZATION ||
+          pNotaryCurrency->proofProtocol == pNotaryCurrency->PROOF_SOLANANOTARIZATION)) ?
+            (CCurrencyDefinition::EProofProtocol)pNotaryCurrency->proofProtocol :
             pNotaryCurrency->PROOF_PBAASMMR);
 
     if (!notarization.SetMirror(false))
@@ -12173,7 +12178,7 @@ bool PreCheckFinalizeNotarization(const CTransaction &tx, int32_t outNum, CValid
             }
             if (LogAcceptCategory("notarization") && LogAcceptCategory("verbose"))
             {
-                LogPrintf("%s: invalid pending finalization on transaction: %s\n");
+                LogPrintf("%s: invalid pending finalization on transaction\n", __func__);
             }
             return state.Error("insufficient evidence to create new pending finalization for notarization");
         }

--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -6163,6 +6163,9 @@ uint32_t CConnectedChains::GetVerusVersion() const
 
 extern string PBAAS_HOST, PBAAS_USERPASS;
 extern int32_t PBAAS_PORT;
+// Solana keeper endpoint, populated by `ConfigureSolBridge()` below.
+extern string SOLANA_HOST, SOLANA_USERPASS;
+extern int32_t SOLANA_PORT;
 bool CConnectedChains::CheckVerusPBaaSAvailable(UniValue &chainInfoUni, UniValue &chainDefUni)
 {
     if (chainInfoUni.isObject() && chainDefUni.isObject())
@@ -6867,6 +6870,81 @@ bool CConnectedChains::ShouldForceRefundDeFi(uint32_t height, const uint160 &cur
     bool inRange = (height >= (PBAAS_REFUND_KAIJU_HEIGHT1 - 1) && (height <= (PBAAS_REFUND_KAIJU_HEIGHT1 + 1))) ||
                    (height >= (PBAAS_REFUND_KAIJU_HEIGHT2 - 1) && (height <= (PBAAS_REFUND_KAIJU_HEIGHT2 + 1)));
     return (_IsVerusActive() && !PBAAS_TESTMODE && inRange && currencyID == KaijuCurrencyID()) ? true : false;
+}
+
+bool CConnectedChains::ConfigureSolBridge(bool callToCheck)
+{
+    // Solana bridge analogue of ConfigureEthBridge — wires up a "sol"
+    // gateway identity to the keeper's RPC endpoint by reading
+    // <datadir>/sol/sol.conf. Mirrors the ETH path so the rest of the
+    // daemon (RPCCallRoot, FirstNotaryChain, IsNotaryAvailable) handles
+    // the resulting NotarySystem entry uniformly.
+    if (!_IsVerusActive())
+    {
+        return false;
+    }
+    if (IsNotaryAvailable())
+    {
+        return true;
+    }
+    LOCK(cs_main);
+    if (FirstNotaryChain().IsValid())
+    {
+        return IsNotaryAvailable(callToCheck);
+    }
+
+    CRPCChainData solNotaryChain;
+    uint160 gatewayParent = ASSETCHAINS_CHAINID;
+    static uint160 gatewayID;
+    if (gatewayID.IsNull())
+    {
+        gatewayID = CIdentity::GetID("sol", gatewayParent);
+    }
+    solNotaryChain.chainDefinition = ConnectedChains.GetCachedCurrency(gatewayID);
+    if (solNotaryChain.chainDefinition.IsValid())
+    {
+        map<string, string> settings;
+        map<string, vector<string>> settingsmulti;
+
+        try
+        {
+            if (ReadConfigFile("sol", settings, settingsmulti) &&
+                settingsmulti.count("-rpchost") &&
+                settingsmulti.count("-rpcuser") &&
+                settingsmulti.count("-rpcport") &&
+                settingsmulti.count("-rpcpassword"))
+            {
+                solNotaryChain.rpcUserPass = SOLANA_USERPASS = settingsmulti.find("-rpcuser")->second[0] + ":" + settingsmulti.find("-rpcpassword")->second[0];
+                solNotaryChain.rpcPort = SOLANA_PORT = atoi(settingsmulti.find("-rpcport")->second[0]);
+                SOLANA_HOST = settingsmulti.find("-rpchost")->second[0];
+            }
+        }
+        catch(const std::exception& e)
+        {
+            LogPrintf("%s: Error reading sol config file - may be invalid or misconfigured\n", __func__);
+        }
+
+        if (!SOLANA_HOST.size())
+        {
+            SOLANA_HOST = "127.0.0.1";
+        }
+        solNotaryChain.rpcHost = SOLANA_HOST;
+        CChainNotarizationData cnd;
+        if (!GetNotarizationData(gatewayID, cnd))
+        {
+            LogPrintf("%s: Failed to get notarization data for solana notary chain %s\n", __func__, solNotaryChain.chainDefinition.name.c_str());
+            return false;
+        }
+
+        notarySystems.insert(std::make_pair(gatewayID,
+                                            CNotarySystemInfo(cnd.IsConfirmed() ? cnd.vtx[cnd.lastConfirmed].second.notarizationHeight : 0,
+                                            solNotaryChain,
+                                            cnd.vtx.size() ? cnd.vtx[cnd.forks[cnd.bestChain].back()].second : CPBaaSNotarization(),
+                                            CNotarySystemInfo::TYPE_SOL,
+                                            CNotarySystemInfo::VERSION_CURRENT)));
+        return IsNotaryAvailable(callToCheck);
+    }
+    return false;
 }
 
 bool CConnectedChains::ConfigureEthBridge(bool callToCheck)

--- a/src/pbaas/pbaas.h
+++ b/src/pbaas/pbaas.h
@@ -934,6 +934,11 @@ public:
         TYPE_PBAAS = 1,
         TYPE_ETH = 2,
         TYPE_KOMODO = 3,
+        // Solana keeper-served notary system. Behaves like TYPE_ETH for
+        // dispatch purposes (RPCCallRoot, witness logic) but the
+        // proof-root format is the Solana on-chain `ProofRoot` PDA, not
+        // an Ethereum patricia tree. See `CProofRoot::TYPE_SOLANA`.
+        TYPE_SOL = 4,
     };
 
     uint32_t notarySystemVersion;
@@ -1226,6 +1231,12 @@ public:
     bool IsVerusPBaaSAvailable();
     bool IsNotaryAvailable(bool callToCheck=false);
     bool ConfigureEthBridge(bool callToCheck=false);
+    // Mirrors ConfigureEthBridge for the Solana keeper. Looks up a
+    // "sol" gateway identity on this chain and reads <datadir>/sol/sol.conf
+    // for keeper RPC creds. Should be invoked AFTER ConfigureEthBridge
+    // — the daemon supports one bridge gateway at a time, so we only
+    // attempt Solana when ETH didn't establish one.
+    bool ConfigureSolBridge(bool callToCheck=false);
     void CheckOracleUpgrades();
     bool IsUpgradeActive(const uint160 &upgradeID, uint32_t blockHeight=UINT32_MAX, uint32_t blockTime=UINT32_MAX) const;
     uint32_t GetZeroViaHeight(bool getVerusHeight) const;

--- a/src/rpc/pbaasrpc.cpp
+++ b/src/rpc/pbaasrpc.cpp
@@ -13945,6 +13945,27 @@ UniValue definecurrency(const UniValue& params, bool fHelp)
     }
     tb.AddTransparentOutput(launchIdentity.IdentityUpdateOutputScript(height + 1), 0);
 
+    // if it's a mapped currency, we don't need to add anything but the definition with no launch period
+    bool isMappedCurrency = newChain.IsToken() &&
+                            !newChain.IsGateway() && !newChain.IsPBaaSChain() &&
+                            !newChain.IsGatewayConverter() &&
+                            newChain.nativeCurrencyID.IsValid() &&
+                            (parentCurrency.IsGateway() || parentCurrency.GetID() == ASSETCHAINS_CHAINID) &&
+                            newChain.systemID != ASSETCHAINS_CHAINID;
+
+    // Gateways, self-currency definitions, and mapped currencies launch
+    // immediately rather than via the prelaunch staging period. The startBlock
+    // override must happen BEFORE the CCurrencyDefinition output is serialized
+    // — otherwise the on-chain definition keeps the validation-default
+    // startBlock (~ height + DEFAULT_PRE_BLOSSOM_TX_EXPIRY_DELTA) and the
+    // accompanying notarization, which is marked launch-complete, fails the
+    // pbaas.cpp:CheckImport "must be for block 1 definitions or gateway
+    // currency" check (importCurrency.startBlock <= height becomes false).
+    if (newChainID == ASSETCHAINS_CHAINID || newChain.IsGateway() || isMappedCurrency)
+    {
+        newChain.startBlock = 1;
+    }
+
     // now, create the currency definition output
     CCcontract_info CC;
     CCcontract_info *cp;
@@ -13965,14 +13986,6 @@ UniValue definecurrency(const UniValue& params, bool fHelp)
     CCoinbaseCurrencyState newCurrencyState;
     uint32_t lastImportHeight = newChain.IsPBaaSChain() || newChain.IsGateway() ? 1 : height;
 
-    // if it's a mapped currency, we don't need to add anything but the definition with no launch period
-    bool isMappedCurrency = newChain.IsToken() &&
-                            !newChain.IsGateway() && !newChain.IsPBaaSChain() &&
-                            !newChain.IsGatewayConverter() &&
-                            newChain.nativeCurrencyID.IsValid() &&
-                            (parentCurrency.IsGateway() || parentCurrency.GetID() == ASSETCHAINS_CHAINID) &&
-                            newChain.systemID != ASSETCHAINS_CHAINID;
-
     CAmount totalLaunchFee = ConnectedChains.ThisChain().GetCurrencyRegistrationFee(newChain.options);
     CAmount notaryFeeShare = 0;
 
@@ -13984,6 +13997,7 @@ UniValue definecurrency(const UniValue& params, bool fHelp)
 
         if (newChain.proofProtocol == newChain.PROOF_PBAASMMR ||
             newChain.proofProtocol == newChain.PROOF_ETHNOTARIZATION ||
+            newChain.proofProtocol == newChain.PROOF_SOLANANOTARIZATION ||
             newChain.proofProtocol == newChain.PROOF_CHAINID)
         {
             dests = std::vector<CTxDestination>({pk.GetID()});


### PR DESCRIPTION
# Summary

This PR is the daemon-side foundation for a Verus ↔ Solana bridge, parallel to the existing veth bridge. It's the first slice of the [community Solana bridge bounty](https://monkins1010.github.io/communityfeedback/bounties/solana/). Receiver-side stack (Anchor program + Rust JSON-RPC keeper + wire-format parser) is built and exercised locally; the daemon changes here are what unblocks running it against a public chain.

## What this PR completes

| File | Change |
|---|---|
| `src/pbaas/crosschainrpc.h` (+24) | `PROOF_SOLANANOTARIZATION = 5`, `TYPE_SOLANA = 4`, `ProofProtocolHashType()` helper that maps Solana → Keccak |
| `src/pbaas/crosschainrpc.cpp` (+60) | Validation gate accepts proofprotocol=5; `RPCCallRoot()` dispatches to `SOLANA_*` globals + `sol.conf` fallback; `gatewayID = GetID()` is now unconditional for any `IsGateway()` (fixes a converter-less gateway producing null source-system) |
| `src/pbaas/notarization.cpp` (+14) | Conditional branches recognize Solana alongside Ethereum |
| `src/pbaas/pbaas.h` (+9) | `ConfigureSolBridge()` declaration; `TYPE_SOL = 4` |
| `src/pbaas/pbaas.cpp` (+66) | `ConfigureSolBridge()` mirrors `ConfigureEthBridge()` for a "sol" gateway identity |
| `src/komodo_globals.h` (+9) | `SOLANA_HOST/PORT/USERPASS` globals (parallel to `PBAAS_*`) |
| `src/init.cpp`, `src/main.cpp`, `src/miner.cpp` (+18) | Try `ConfigureEthBridge` first, fall back to `ConfigureSolBridge` if no "veth" gateway exists; two `LogPrintf` format-string fixes that were silently masking real errors as `tinyformat: Not enough conversion specifiers` |
| `src/rpc/pbaasrpc.cpp` (+18) | `definecurrency`: `PROOF_SOLANANOTARIZATION` added to the import-thread proofProtocol whitelist (a *second* allowlist, separate from the JSON-ctor gate); reorders `newChain.startBlock = 1` to fire BEFORE the currency-definition output is serialized so converter-less gateway launches pass `pbaas.cpp:CheckImport`'s "block 1 or gateway" gate |

